### PR TITLE
feat: create id in domain

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,5 +1,6 @@
 SECRET_KEY=secret_key
 ENVIRONMENT=test
+DATABASE_TYPE=sql
 
 # PostgreSQL
 POSTGRES_USER=user

--- a/app/api/dependencies.py
+++ b/app/api/dependencies.py
@@ -1,3 +1,4 @@
+import uuid
 from functools import lru_cache
 from typing import Annotated
 
@@ -48,7 +49,7 @@ async def get_current_user(
     if user_id is None:
         raise credential_exception
 
-    user = domain.get_user(user_id=user_id)
+    user = domain.get_user(user_id=uuid.UUID(user_id))
     if user is None:
         raise credential_exception
 

--- a/app/cli/utils.py
+++ b/app/cli/utils.py
@@ -51,12 +51,9 @@ def make_model_parser(model: type[BaseModel]) -> Callable[[str], BaseModel]:
 
 def parse_entity_id(value: str) -> EntityId:
     try:
-        uuid.UUID(value)
-        return value
-    except ValueError:
-        if object_id_pattern.match(value):
-            return value
-    raise typer.BadParameter("Must be UUID or ObjectId.")
+        return uuid.UUID(value)
+    except ValueError as error:
+        raise typer.BadParameter("Must be UUID or ObjectId.") from error
 
 
 def print_result(result: Any, title: str, border_style: str = "none") -> None:

--- a/app/core/context/mongo.py
+++ b/app/core/context/mongo.py
@@ -19,7 +19,7 @@ class MongoContext(TransactionalContextProtocol):
 
     @classmethod
     def initialize(cls, settings: Settings) -> None:
-        cls.client = MongoClient(settings.mongo_uri)
+        cls.client = MongoClient(settings.mongo_uri, uuidRepresentation="standard")
         cls._database = cls.client[settings.mongo_database]
 
     @contextmanager

--- a/app/domain/entities.py
+++ b/app/domain/entities.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, ConfigDict, NonNegativeInt, PositiveInt
 
 T = TypeVar("T", bound="DomainModel")
 
-type EntityId = uuid.UUID | str
+type EntityId = uuid.UUID
 
 
 DEFAULT_PAGINATION_LIMIT = 10
@@ -14,7 +14,7 @@ DEFAULT_PAGINATION_LIMIT = 10
 class DomainModel(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
-    id: EntityId | None
+    id: EntityId
 
 
 class Token(BaseModel):

--- a/app/domain/posts/commands.py
+++ b/app/domain/posts/commands.py
@@ -1,3 +1,5 @@
+import uuid
+
 from app.domain.context import ContextProtocol
 from app.domain.entities import EntityId, PaginatedResponse, Pagination
 from app.domain.exceptions import NotFoundError
@@ -10,7 +12,7 @@ def create_post_command(context: ContextProtocol, data: PostCreate) -> Post:
         raise NotFoundError(f"User '{data.author_id}' not found.")
 
     post = Post(
-        id=None,
+        id=uuid.uuid4(),
         title=data.title,
         content=data.content,
         author_id=author.id,
@@ -31,6 +33,7 @@ def get_post_command(context: ContextProtocol, post_id: EntityId) -> Post:
     post = context.post_repository.get_by_id(post_id)
     if not post:
         raise NotFoundError(f"Post '{post_id}' not found")
+
     return post
 
 

--- a/app/domain/users/commands.py
+++ b/app/domain/users/commands.py
@@ -1,3 +1,5 @@
+import uuid
+
 from app.core.security import get_password_hash, verify_password
 from app.domain.context import ContextProtocol
 from app.domain.entities import EntityId, PaginatedResponse, Pagination
@@ -25,7 +27,7 @@ def create_user_command(context: ContextProtocol, data: UserCreate) -> User:
         raise AlreadyExistsError(f"User '{data.email}' already exists.")
 
     user = User(
-        id=None,
+        id=uuid.uuid4(),
         email=data.email,
         username=data.username,
         hashed_password=get_password_hash(data.password),
@@ -46,6 +48,7 @@ def get_user_command(context: ContextProtocol, user_id: EntityId) -> User:
     user = context.user_repository.get_by_id(user_id)
     if not user:
         raise NotFoundError(f"User '{user_id}' not found.")
+
     return user
 
 

--- a/app/infrastructure/mongo/posts.py
+++ b/app/infrastructure/mongo/posts.py
@@ -12,11 +12,10 @@ class PostMongoRepository(
     searchable_fields = ("title", "content")
 
     def _to_domain_entity(self, document: MongoDocument, /) -> Post:
-        # Override to convert ObjectId 'author_id' to string
         return Post(
-            id=str(document["_id"]),
+            id=document["_id"],
             title=document["title"],
             content=document["content"],
-            author_id=str(document["author_id"]),
+            author_id=document["author_id"],
             tags=document.get("tags", []),
         )

--- a/app/infrastructure/mongo/users.py
+++ b/app/infrastructure/mongo/users.py
@@ -14,16 +14,16 @@ class UserMongoRepository(BaseMongoRepository[User], UserRepositoryProtocol):
 
     def _to_domain_entity(self, document: MongoDocument, /) -> User:
         return User(
-            id=str(document["_id"]),
+            id=document["_id"],
             email=document["email"],
             username=document["username"],
             hashed_password=document["hashed_password"],
             posts=[
                 Post(
-                    id=str(post["_id"]),
+                    id=post["_id"],
                     title=post["title"],
                     content=post["content"],
-                    author_id=str(post["author_id"]),
+                    author_id=post["author_id"],
                     tags=post.get("tags", []),
                 )
                 for post in document.get("posts", [])
@@ -32,7 +32,9 @@ class UserMongoRepository(BaseMongoRepository[User], UserRepositoryProtocol):
 
     @staticmethod
     def _to_database_entity(entity: User, /) -> MongoDocument:
-        return entity.model_dump(exclude={"id", "posts"})
+        document = entity.model_dump(exclude={"id", "posts"})
+        document["_id"] = entity.id
+        return document
 
     @staticmethod
     def _aggregation_pipeline() -> list[MongoDocument]:

--- a/app/infrastructure/sql/base.py
+++ b/app/infrastructure/sql/base.py
@@ -59,8 +59,6 @@ class BaseSqlRepository(BaseRepositoryProtocol[Domain_T], Generic[Domain_T, Orm_
         return self._to_domain_entity(orm_entity)
 
     def update(self, entity: Domain_T, /) -> Domain_T:
-        assert entity.id is not None
-
         db_entity = self._get_db_entity(entity_id=entity.id)
         if not db_entity:
             raise RuntimeError()

--- a/app/infrastructure/sql/models.py
+++ b/app/infrastructure/sql/models.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
 
 class OrmBase(DeclarativeBase):
-    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True)
 
 
 post_tag = Table(

--- a/app/infrastructure/sql/posts.py
+++ b/app/infrastructure/sql/posts.py
@@ -1,3 +1,5 @@
+import uuid
+
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
@@ -34,7 +36,7 @@ class PostSqlRepository(BaseSqlRepository[Post, OrmPost], PostRepositoryProtocol
             stmt = select(OrmTag).where(OrmTag.name == tag_name)
             orm_tag = self.session.scalar(stmt)
             if not orm_tag:
-                orm_tag = OrmTag(name=tag_name)
+                orm_tag = OrmTag(id=uuid.uuid4(), name=tag_name)
                 self.session.add(orm_tag)
 
             orm_entity.tags.append(orm_tag)
@@ -45,7 +47,7 @@ class PostSqlRepository(BaseSqlRepository[Post, OrmPost], PostRepositoryProtocol
             title=entity.title,
             content=entity.content,
             author_id=entity.author_id,
-            tags=[OrmTag(name=tag) for tag in entity.tags],
+            tags=[OrmTag(id=uuid.uuid4(), name=tag) for tag in entity.tags],
         )
 
     def _to_domain_entity(self, orm_entity: OrmPost, /) -> Post:

--- a/app/infrastructure/sql/users.py
+++ b/app/infrastructure/sql/users.py
@@ -20,8 +20,6 @@ class UserSqlRepository(BaseSqlRepository[User, OrmUser], UserRepositoryProtocol
         return self._to_domain_entity(orm_entity=orm_entity) if orm_entity else None
 
     def update(self, entity: User, /) -> User:
-        assert entity.id is not None
-
         db_entity = self._get_db_entity(entity_id=entity.id)
         if not db_entity:
             raise RuntimeError()

--- a/tests/api/posts/test_router.py
+++ b/tests/api/posts/test_router.py
@@ -1,7 +1,9 @@
+import uuid
+
 from fastapi import status
 from fastapi.testclient import TestClient
 
-from app.domain.entities import DEFAULT_PAGINATION_LIMIT, EntityId
+from app.domain.entities import DEFAULT_PAGINATION_LIMIT
 from tests.fixtures.factories.posts.base import PostBaseFactory
 from tests.fixtures.factories.users.base import UserBaseFactory
 
@@ -39,13 +41,14 @@ def test_get_post(post_factory: PostBaseFactory, client: TestClient) -> None:
     assert result["tags"] == post.tags
 
 
-def test_get_post_not_found(fake_entity_id: EntityId, client: TestClient) -> None:
+def test_get_post_not_found(client: TestClient) -> None:
     # Act
-    response = client.get(f"/posts/{fake_entity_id}")
+    entity_id = uuid.uuid4()
+    response = client.get(f"/posts/{entity_id}")
 
     # Assert
     assert response.status_code == status.HTTP_404_NOT_FOUND
-    assert response.json() == {"detail": f"Post '{fake_entity_id}' not found"}
+    assert response.json() == {"detail": f"Post '{entity_id}' not found"}
 
 
 def test_create_post(user_factory: UserBaseFactory, client: TestClient) -> None:
@@ -70,14 +73,12 @@ def test_create_post(user_factory: UserBaseFactory, client: TestClient) -> None:
     assert result["tags"] == data["tags"]
 
 
-def test_create_post_user_not_found(
-    fake_entity_id: EntityId, client: TestClient
-) -> None:
+def test_create_post_user_not_found(client: TestClient) -> None:
     # Act
     data = {
         "title": "Post",
         "content": "Post content",
-        "author_id": fake_entity_id,
+        "author_id": str(uuid.uuid4()),
         "tags": ["python", "fastapi"],
     }
     response = client.post("/posts", json=data)
@@ -167,14 +168,15 @@ def test_update_post_remove_all_tags(
     assert result["tags"] == data["tags"]
 
 
-def test_update_post_not_found(fake_entity_id: EntityId, client: TestClient) -> None:
+def test_update_post_not_found(client: TestClient) -> None:
     # Act
+    entity_id = uuid.uuid4()
     data = {"title": "Post Updated"}
-    response = client.patch(f"/posts/{fake_entity_id}", json=data)
+    response = client.patch(f"/posts/{entity_id}", json=data)
 
     # Assert
     assert response.status_code == status.HTTP_404_NOT_FOUND
-    assert response.json() == {"detail": f"Post '{fake_entity_id}' not found"}
+    assert response.json() == {"detail": f"Post '{entity_id}' not found"}
 
 
 def test_delete_post(post_factory: PostBaseFactory, client: TestClient) -> None:
@@ -192,11 +194,12 @@ def test_delete_post(post_factory: PostBaseFactory, client: TestClient) -> None:
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
-def test_delete_post_not_found(fake_entity_id: EntityId, client: TestClient) -> None:
+def test_delete_post_not_found(client: TestClient) -> None:
     # Act
-    response = client.delete(f"/posts/{fake_entity_id}")
+    entity_id = uuid.uuid4()
+    response = client.delete(f"/posts/{entity_id}")
 
     # Assert
     assert response.status_code == status.HTTP_404_NOT_FOUND
     result = response.json()
-    assert result == {"detail": f"Post '{fake_entity_id}' not found."}
+    assert result == {"detail": f"Post '{entity_id}' not found."}

--- a/tests/api/users/test_router.py
+++ b/tests/api/users/test_router.py
@@ -1,7 +1,9 @@
+import uuid
+
 from fastapi import status
 from fastapi.testclient import TestClient
 
-from app.domain.entities import DEFAULT_PAGINATION_LIMIT, EntityId
+from app.domain.entities import DEFAULT_PAGINATION_LIMIT
 from tests.fixtures.factories.posts.base import PostBaseFactory
 from tests.fixtures.factories.users.base import UserBaseFactory
 
@@ -43,14 +45,15 @@ def test_get_user(
     assert [post["id"] for post in result["posts"]] == [str(post.id) for post in posts]
 
 
-def test_get_user_not_found(fake_entity_id: EntityId, client: TestClient) -> None:
+def test_get_user_not_found(client: TestClient) -> None:
     # Act
-    response = client.get(f"/users/{fake_entity_id}")
+    entity_id = uuid.uuid4()
+    response = client.get(f"/users/{entity_id}")
 
     # Assert
     assert response.status_code == status.HTTP_404_NOT_FOUND
     result = response.json()
-    assert result == {"detail": f"User '{fake_entity_id}' not found."}
+    assert result == {"detail": f"User '{entity_id}' not found."}
 
 
 def test_create_user(client: TestClient) -> None:
@@ -111,14 +114,15 @@ def test_update_user(
     assert [post["id"] for post in result["posts"]] == [str(post.id) for post in posts]
 
 
-def test_update_user_not_found(fake_entity_id: EntityId, client: TestClient) -> None:
+def test_update_user_not_found(client: TestClient) -> None:
     # Act
+    entity_id = uuid.uuid4()
     data = {"username": "User Updated"}
-    response = client.patch(f"/users/{fake_entity_id}", json=data)
+    response = client.patch(f"/users/{entity_id}", json=data)
 
     # Assert
     assert response.status_code == status.HTTP_404_NOT_FOUND
-    assert response.json() == {"detail": f"User '{fake_entity_id}' not found"}
+    assert response.json() == {"detail": f"User '{entity_id}' not found"}
 
 
 def test_delete_user(user_factory: UserBaseFactory, client: TestClient) -> None:
@@ -136,10 +140,11 @@ def test_delete_user(user_factory: UserBaseFactory, client: TestClient) -> None:
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
-def test_delete_user_not_found(fake_entity_id: EntityId, client: TestClient) -> None:
+def test_delete_user_not_found(client: TestClient) -> None:
     # Act
-    response = client.delete(f"/users/{fake_entity_id}")
+    entity_id = uuid.uuid4()
+    response = client.delete(f"/users/{entity_id}")
 
     # Assert
     assert response.status_code == status.HTTP_404_NOT_FOUND
-    assert response.json() == {"detail": f"User '{fake_entity_id}' not found"}
+    assert response.json() == {"detail": f"User '{entity_id}' not found"}

--- a/tests/cli/posts/test_cli.py
+++ b/tests/cli/posts/test_cli.py
@@ -1,7 +1,8 @@
+import uuid
+
 import typer
 from typer.testing import CliRunner
 
-from app.domain.entities import EntityId
 from tests.fixtures.factories.posts.base import PostBaseFactory
 from tests.fixtures.factories.users.base import UserBaseFactory
 
@@ -30,11 +31,9 @@ def test_get_post(
     assert f"id=UUID('{post.id}')" in result.output
 
 
-def test_get_post_not_found(
-    fake_entity_id: EntityId, cli_app: typer.Typer, cli_runner: CliRunner
-) -> None:
+def test_get_post_not_found(cli_app: typer.Typer, cli_runner: CliRunner) -> None:
     # Act
-    result = cli_runner.invoke(cli_app, ["posts", "get", str(fake_entity_id)])
+    result = cli_runner.invoke(cli_app, ["posts", "get", str(uuid.uuid4())])
 
     # Assert
     assert result.exit_code == 1
@@ -94,12 +93,10 @@ def test_update_post(
     assert "Post updated" in result.output
 
 
-def test_update_post_not_found(
-    fake_entity_id: EntityId, cli_app: typer.Typer, cli_runner: CliRunner
-) -> None:
+def test_update_post_not_found(cli_app: typer.Typer, cli_runner: CliRunner) -> None:
     # Act
     data = '{"title": "Update"}'
-    result = cli_runner.invoke(cli_app, ["posts", "update", str(fake_entity_id), data])
+    result = cli_runner.invoke(cli_app, ["posts", "update", str(uuid.uuid4()), data])
 
     # Assert
     assert result.exit_code == 1
@@ -136,11 +133,9 @@ def test_delete_post(
     assert "Post deleted" in result.output
 
 
-def test_delete_post_not_found(
-    fake_entity_id: EntityId, cli_app: typer.Typer, cli_runner: CliRunner
-) -> None:
+def test_delete_post_not_found(cli_app: typer.Typer, cli_runner: CliRunner) -> None:
     # Act
-    result = cli_runner.invoke(cli_app, ["posts", "delete", str(fake_entity_id)])
+    result = cli_runner.invoke(cli_app, ["posts", "delete", str(uuid.uuid4())])
 
     # Assert
     assert result.exit_code == 1

--- a/tests/cli/users/test_cli.py
+++ b/tests/cli/users/test_cli.py
@@ -1,7 +1,8 @@
+import uuid
+
 import typer
 from typer.testing import CliRunner
 
-from app.domain.entities import EntityId
 from tests.fixtures.factories.users.base import UserBaseFactory
 
 
@@ -29,11 +30,9 @@ def test_get_user(
     assert f"id=UUID('{user.id}')" in result.output
 
 
-def test_get_user_not_found(
-    fake_entity_id: EntityId, cli_app: typer.Typer, cli_runner: CliRunner
-) -> None:
+def test_get_user_not_found(cli_app: typer.Typer, cli_runner: CliRunner) -> None:
     # Act
-    result = cli_runner.invoke(cli_app, ["users", "get", str(fake_entity_id)])
+    result = cli_runner.invoke(cli_app, ["users", "get", str(uuid.uuid4())])
 
     # Assert
     assert result.exit_code == 1
@@ -107,12 +106,10 @@ def test_update_user(
     assert "User updated" in result.output
 
 
-def test_update_user_not_found(
-    fake_entity_id: EntityId, cli_app: typer.Typer, cli_runner: CliRunner
-) -> None:
+def test_update_user_not_found(cli_app: typer.Typer, cli_runner: CliRunner) -> None:
     # Act
     data = '{"username": "User Updated"}'
-    result = cli_runner.invoke(cli_app, ["users", "update", str(fake_entity_id), data])
+    result = cli_runner.invoke(cli_app, ["users", "update", str(uuid.uuid4()), data])
 
     # Assert
     assert result.exit_code == 1
@@ -149,11 +146,9 @@ def test_delete_user(
     assert "User deleted" in result.output
 
 
-def test_delete_user_not_found(
-    fake_entity_id: EntityId, cli_app: typer.Typer, cli_runner: CliRunner
-) -> None:
+def test_delete_user_not_found(cli_app: typer.Typer, cli_runner: CliRunner) -> None:
     # Act
-    result = cli_runner.invoke(cli_app, ["users", "delete", str(fake_entity_id)])
+    result = cli_runner.invoke(cli_app, ["users", "delete", str(uuid.uuid4())])
 
     # Assert
     assert result.exit_code == 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,10 @@
 import logging
-import uuid
 from collections.abc import AsyncIterator, Iterator
 from functools import lru_cache
 from pathlib import Path
 
 import pytest
 import typer
-from bson import ObjectId
 from fastapi.testclient import TestClient
 from httpx import ASGITransport, AsyncClient
 from typer.testing import CliRunner
@@ -15,10 +13,11 @@ from app.api.app import create_app
 from app.api.dependencies import get_settings
 from app.cli.app import create_cli_app
 from app.core.config import DatabaseType, Settings
+from app.core.context.mongo import MongoContext
 from app.core.context.sql import SqlContext
+from app.core.context.utils import get_context
 from app.core.security import create_access_token
-from app.domain.domain import Domain
-from app.domain.entities import EntityId
+from app.domain.domain import Domain, TransactionalContextProtocol
 from tests.fixtures.factories.users.base import UserBaseFactory
 
 logger = logging.getLogger(__name__)
@@ -37,21 +36,30 @@ def get_test_settings() -> Settings:
     return Settings(_env_file=project_dir / ".env.test")
 
 
+def get_test_context() -> TransactionalContextProtocol:
+    settings = get_test_settings()
+    match settings.database_type:
+        case DatabaseType.SQL:
+            return SqlContext()
+        case DatabaseType.MONGO:
+            return MongoContext()
+
+
+def initialize_context() -> None:
+    settings = get_test_settings()
+    match settings.database_type:
+        case DatabaseType.SQL:
+            SqlContext.initialize(settings=settings)
+        case DatabaseType.MONGO:
+            MongoContext.initialize(settings=settings)
+
+
 @pytest.fixture(scope="session")
 def settings() -> Settings:
     settings_ = get_test_settings()
     logger.info(f"Loading settings for {settings_.environment} environment")
-    SqlContext.initialize(settings=settings_)
+    initialize_context()
     return settings_
-
-
-@pytest.fixture
-def fake_entity_id(settings: Settings) -> EntityId:
-    match settings.database_type:
-        case DatabaseType.SQL:
-            return str(uuid.uuid4())
-        case DatabaseType.MONGO:
-            return str(ObjectId())
 
 
 @pytest.fixture
@@ -61,6 +69,7 @@ def client(user_factory: UserBaseFactory, settings: Settings) -> Iterator[TestCl
 
     app = create_app(settings=settings)
     app.dependency_overrides[get_settings] = get_test_settings
+    app.dependency_overrides[get_context] = get_test_context
 
     client = TestClient(app)
     client.headers["Authorization"] = f"Bearer {token_data.access_token}"
@@ -75,6 +84,8 @@ def anyio_backend() -> str:
 @pytest.fixture
 async def client_async(settings: Settings) -> AsyncIterator[AsyncClient]:
     app = create_app(settings=settings)
+    app.dependency_overrides[get_settings] = get_test_settings
+    app.dependency_overrides[get_context] = get_test_context
 
     async with AsyncClient(
         transport=ASGITransport(app=app),
@@ -90,6 +101,6 @@ def cli_runner() -> CliRunner:
 
 @pytest.fixture
 def cli_app(settings: Settings) -> typer.Typer:
-    context = SqlContext()
+    context = get_test_context()
     domain = Domain(context=context)
     return create_cli_app(domain=domain)

--- a/tests/fixtures/database/mongo.py
+++ b/tests/fixtures/database/mongo.py
@@ -10,7 +10,9 @@ from app.infrastructure.mongo.base import MongoDocument
 
 @pytest.fixture
 def mongo_db(settings: Settings) -> Iterator[Database[MongoDocument]]:
-    client: MongoClient[MongoDocument] = MongoClient(settings.mongo_uri)
+    client: MongoClient[MongoDocument] = MongoClient(
+        settings.mongo_uri, uuidRepresentation="standard"
+    )
     database: Database[MongoDocument] = client[settings.mongo_database]
 
     yield database

--- a/tests/fixtures/factories/base.py
+++ b/tests/fixtures/factories/base.py
@@ -8,18 +8,23 @@ T = TypeVar("T", bound=DomainModel)
 class BaseFactory(Generic[T]):
     def create_one(self, **kwargs: Any) -> T:
         entity = self._build_entity(**kwargs)
-        self._insert([entity])
+        self._insert_many([entity])
         return entity
 
     def create_many(self, count: int, /, **kwargs: Any) -> list[T]:
         entities = [self._build_entity(**kwargs) for _ in range(count)]
-        self._insert(entities)
+        self._insert_many(entities)
         return entities
 
     def _build_entity(self, **kwargs: Any) -> T:
         """Build a domain entity with the given kwargs."""
         raise NotImplementedError()
 
-    def _insert(self, entities: list[T]) -> None:
-        """Insert the entities into the database."""
+    def _insert_many(self, entities: list[T]) -> None:
+        """Insert multiple entities into the database."""
+        for entity in entities:
+            self._insert_one(entity)
+
+    def _insert_one(self, entity: T) -> None:
+        """Insert a single entity into the database."""
         raise NotImplementedError()

--- a/tests/fixtures/factories/generics.py
+++ b/tests/fixtures/factories/generics.py
@@ -1,9 +1,0 @@
-# from typing import Any
-#
-# from app.domain.generics.entities import GenericEntity
-# from tests.fixtures.factories.mongo import MongoBaseFactory
-#
-#
-# class GenericEntityMongoFactory(MongoBaseFactory[GenericEntity]):
-#     def _build_entity(self, **kwargs: Any) -> GenericEntity:
-#         return GenericEntity(id=None, name=kwargs.get("name", self.faker.name()))

--- a/tests/fixtures/factories/mongo.py
+++ b/tests/fixtures/factories/mongo.py
@@ -13,11 +13,11 @@ class MongoBaseFactory(BaseFactory[T], Generic[T]):
     def __init__(self, collection: Collection[MongoDocument]):
         self.collection = collection
 
-    def _insert(self, entities: list[T]) -> None:
-        for entity in entities:
-            db_entity = self._to_database_entity(entity)
-            result = self.collection.insert_one(db_entity)
-            entity.id = str(result.inserted_id)
+    def _insert_one(self, entity: T) -> None:
+        db_entity = self._to_database_entity(entity)
+        self.collection.insert_one(db_entity)
 
     def _to_database_entity(self, entity: T, /) -> MongoDocument:
-        return entity.model_dump(exclude={"id"})
+        document = entity.model_dump(exclude={"id"})
+        document["_id"] = entity.id
+        return document

--- a/tests/fixtures/factories/posts/base.py
+++ b/tests/fixtures/factories/posts/base.py
@@ -1,3 +1,4 @@
+import uuid
 from typing import Any, TypeVar
 
 from faker import Faker
@@ -26,7 +27,7 @@ class PostBaseFactory(BaseFactory[Post]):
             ]
 
         return Post(
-            id=None,
+            id=uuid.uuid4(),
             title=kwargs.get("title", self.faker.sentence()),
             content=kwargs.get("content", self.faker.text()),
             author_id=author_id,

--- a/tests/fixtures/factories/posts/mongo.py
+++ b/tests/fixtures/factories/posts/mongo.py
@@ -1,4 +1,3 @@
-from bson import ObjectId
 from pymongo.collection import Collection
 
 from app.domain.posts.entities import Post
@@ -16,8 +15,3 @@ class PostMongoFactory(MongoBaseFactory[Post], PostBaseFactory):
     ) -> None:
         MongoBaseFactory.__init__(self, collection=collection)
         PostBaseFactory.__init__(self, user_factory=user_factory)
-
-    def _to_database_entity(self, entity: Post, /) -> MongoDocument:
-        db_entity = entity.model_dump(exclude={"id"})
-        db_entity["author_id"] = ObjectId(str(entity.author_id))
-        return db_entity

--- a/tests/fixtures/factories/posts/sql.py
+++ b/tests/fixtures/factories/posts/sql.py
@@ -1,3 +1,5 @@
+import uuid
+
 from sqlalchemy.orm import Session
 
 from app.domain.posts.entities import Post
@@ -18,5 +20,5 @@ class PostSqlFactory(SqlBaseFactory[Post, OrmPost], PostBaseFactory):
             title=entity.title,
             content=entity.content,
             author_id=entity.author_id,
-            tags=[OrmTag(name=tag) for tag in entity.tags],
+            tags=[OrmTag(id=uuid.uuid4(), name=tag) for tag in entity.tags],
         )

--- a/tests/fixtures/factories/sql.py
+++ b/tests/fixtures/factories/sql.py
@@ -14,12 +14,11 @@ class SqlBaseFactory(BaseFactory[T], Generic[T, P]):
     def __init__(self, session: Session):
         self.session = session
 
-    def _insert(self, entities: list[T]) -> None:
-        for entity in entities:
-            db_entity = self._to_database_entity(entity)
-            self.session.add(db_entity)
-            self.session.commit()
-            entity.id = db_entity.id
+    def _insert_one(self, entity: T) -> None:
+        db_entity = self._to_database_entity(entity)
+        self.session.add(db_entity)
+        self.session.commit()
 
     def _to_database_entity(self, entity: T) -> P:
+        """Must be implemented in subclasses for the Orm Entity"""
         raise NotImplementedError()

--- a/tests/fixtures/factories/users/base.py
+++ b/tests/fixtures/factories/users/base.py
@@ -1,3 +1,4 @@
+import uuid
 from typing import Any
 
 from faker import Faker
@@ -18,7 +19,7 @@ class UserBaseFactory(BaseFactory[User]):
         )
 
         return User(
-            id=None,
+            id=uuid.uuid4(),
             email=kwargs.get("email", self.faker.unique.email()),
             username=kwargs.get("username", self.faker.user_name()),
             hashed_password=kwargs.get("hashed_password", hashed_password),

--- a/tests/fixtures/factories/users/mongo.py
+++ b/tests/fixtures/factories/users/mongo.py
@@ -12,4 +12,6 @@ class UserMongoFactory(MongoBaseFactory[User], UserBaseFactory):
         UserBaseFactory.__init__(self)
 
     def _to_database_entity(self, entity: User, /) -> MongoDocument:
-        return entity.model_dump(exclude={"id", "posts"})
+        document = entity.model_dump(exclude={"id", "posts"})
+        document["_id"] = entity.id
+        return document


### PR DESCRIPTION
…actions

## Summary by Sourcery

Generate entity IDs at the domain layer and update repositories, factories, tests, and context wiring to treat IDs as native UUIDs across SQL and Mongo implementations.

New Features:
- Create UUIDs for new domain entities at the command layer instead of relying on repository-generated IDs

Enhancements:
- Change EntityId type to uuid.UUID and remove string/ObjectId conversions in repositories
- Update BaseMongoRepository and Mongo/SQL repositories to use entity.id as the primary key
- Refactor test fixtures to replace the fake_entity_id fixture with on-the-fly UUID generation and introduce get_test_context for context injection
- Unify BaseFactory insertion methods (_insert_one and _insert_many) and adjust concrete factories accordingly
- Add get_context dependency override in test clients for consistent context resolution
- Configure MongoClient with uuidRepresentation="standard" in core context and test setup
- Simplify CLI parse_entity_id to always return a uuid.UUID

Tests:
- Update API and CLI tests to generate UUIDs in place of the fake_entity_id fixture
- Adjust tests to reflect ID type changes and new context overrides